### PR TITLE
inherit from Volt:ModelController to evade crash

### DIFF
--- a/app/editable-text/controllers/main_controller.rb
+++ b/app/editable-text/controllers/main_controller.rb
@@ -1,5 +1,5 @@
 module EditableText
-  class MainController < ModelController
+  class MainController < Volt::ModelController
     attr_accessor :section
     reactive_accessor :toggled
 


### PR DESCRIPTION
I forgot to add this change to the commits of my previous pull request, sorry for that!

Without the change it throws this error when you run volt server:

`/controllers/main_controller.rb:2:in '<module:EditableText>': uninitialized constant EditableText::ModelController (NameError)`
